### PR TITLE
Propagate line comments in GRBL M0/M1/M6 commands to UI dialog

### DIFF
--- a/src/app/containers/Workspace/Workspace.jsx
+++ b/src/app/containers/Workspace/Workspace.jsx
@@ -151,7 +151,7 @@ class Workspace extends PureComponent {
                 return;
             }
 
-            const { err, data } = { ...holdReason };
+            const { err, data, message } = { ...holdReason };
 
             if (err) {
                 this.action.openModal(MODAL_FEEDER_PAUSED, {
@@ -178,7 +178,8 @@ class Workspace extends PureComponent {
             }[data] || data;
 
             this.action.openModal(MODAL_FEEDER_PAUSED, {
-                title: title
+                title: title,
+                message: message
             });
         }
     };
@@ -433,6 +434,7 @@ class Workspace extends PureComponent {
                 {modal.name === MODAL_FEEDER_PAUSED && (
                     <FeederPaused
                         title={modal.params.title}
+                        message={modal.params.message}
                         onClose={this.action.closeModal}
                     />
                 )}

--- a/src/app/containers/Workspace/modals/FeederPaused.jsx
+++ b/src/app/containers/Workspace/modals/FeederPaused.jsx
@@ -16,6 +16,9 @@ const FeederPaused = (props) => (
         <Modal.Body>
             <ModalTemplate type="warning">
                 <h5>{props.title}</h5>
+                {props.message &&
+                <p>{props.message}</p>
+                }
                 <p>{i18n._('Click the Continue button to resume execution.')}</p>
             </ModalTemplate>
         </Modal.Body>
@@ -48,6 +51,7 @@ const FeederPaused = (props) => (
 
 FeederPaused.propTypes = {
     title: PropTypes.string,
+    message: PropTypes.string,
     onClose: PropTypes.func
 };
 


### PR DESCRIPTION
Capture any line comment (everything after a semicolon) on an M0, M1
or M6 command and display is as part of the pause dialog in the UI.

Fixes #467.